### PR TITLE
Remove conditional compilation around DisposeAsync

### DIFF
--- a/src/PlaywrightSharp.Abstractions/IBrowser.cs
+++ b/src/PlaywrightSharp.Abstractions/IBrowser.cs
@@ -9,12 +9,7 @@ namespace PlaywrightSharp
     /// <summary>
     /// A Browser is created when Playwright connects to a browser instance.
     /// </summary>
-    public interface IBrowser : IDisposable
-#if NETSTANDARD2_1
-#pragma warning disable SA1001 // Space after comma
-, IAsyncDisposable
-#pragma warning restore SA1001 // Space after comma
-#endif
+    public interface IBrowser : IDisposable, IAsyncDisposable
     {
         /// <summary>
         /// Raised when the url of a target changes

--- a/src/PlaywrightSharp.Abstractions/PlaywrightSharp.Abstractions.csproj
+++ b/src/PlaywrightSharp.Abstractions/PlaywrightSharp.Abstractions.csproj
@@ -18,6 +18,7 @@
     </PropertyGroup>
     <Import Project="../Common/Dependencies.props" />
     <ItemGroup>
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.0" />
         <PackageReference Include="System.Json" Version="4.7.0" />
         <PackageReference Include="System.Text.Json" Version="4.7.0" />
     </ItemGroup>

--- a/src/PlaywrightSharp.Chromium/ChromiumBrowser.cs
+++ b/src/PlaywrightSharp.Chromium/ChromiumBrowser.cs
@@ -102,10 +102,8 @@ namespace PlaywrightSharp.Chromium
         /// <inheritdoc cref="IDisposable.Dispose"/>
         public void Dispose() => _ = CloseAsync();
 
-#if NETSTANDARD2_1
         /// <inheritdoc cref="IAsyncDisposable.DisposeAsync"/>
         public ValueTask DisposeAsync() => new ValueTask(CloseAsync());
-#endif
 
         /// <inheritdoc cref="IBrowser.NewContextAsync"/>
         public async Task<IBrowserContext> NewContextAsync(BrowserContextOptions options = null)


### PR DESCRIPTION
Fixes #272 

The reference to  `Microsoft.Bcl.AsyncInterfaces` doesn't need to be explicit as it is pulled in via `System.Text.Json`, happy to keep it in or remove it 😃 