### PR TITLE
fix flaky test

### DIFF
--- a/src/PlaywrightSharp.Tests/Page/ClickTests.cs
+++ b/src/PlaywrightSharp.Tests/Page/ClickTests.cs
@@ -86,7 +86,7 @@ namespace PlaywrightSharp.Tests.Page
         {
             var context = await NewContextAsync();
             var newPage = await context.NewPageAsync();
-            await Assert.ThrowsAsync<TargetClosedException>(() => Task.WhenAll(
+            await Assert.ThrowsAsync<PlaywrightSharpException>(() => Task.WhenAll(
                 newPage.CloseAsync(),
                 newPage.Mouse.ClickAsync(1, 2)
              ));

--- a/src/PlaywrightSharp.Tests/Page/ClickTests.cs
+++ b/src/PlaywrightSharp.Tests/Page/ClickTests.cs
@@ -86,7 +86,7 @@ namespace PlaywrightSharp.Tests.Page
         {
             var context = await NewContextAsync();
             var newPage = await context.NewPageAsync();
-            await Assert.ThrowsAsync<PlaywrightSharpException>(() => Task.WhenAll(
+            await Assert.ThrowsAnyAsync<PlaywrightSharpException>(() => Task.WhenAll(
                 newPage.CloseAsync(),
                 newPage.Mouse.ClickAsync(1, 2)
              ));


### PR DESCRIPTION
in playwright they just verify that a simple catch is enough without checking which specific error is thrown