### PR TITLE
Firefox: Pass GeolocationTests

### DIFF
--- a/src/PlaywrightSharp.Firefox/FirefoxBrowserContext.cs
+++ b/src/PlaywrightSharp.Firefox/FirefoxBrowserContext.cs
@@ -45,9 +45,7 @@ namespace PlaywrightSharp.Firefox
 
         /// <inheritdoc cref="IBrowserContextDelegate.SetGeolocationAsync(GeolocationOption)"/>
         public Task SetGeolocationAsync(GeolocationOption geolocation)
-        {
-            throw new System.NotImplementedException();
-        }
+            => throw new NotSupportedException("Geolocation emulation is not supported in Firefox");
 
         /// <inheritdoc cref="IBrowserContextDelegate.CloseAsync"/>
         public async Task CloseAsync()

--- a/src/PlaywrightSharp.Tests/BrowserContext/GeolocationTests.cs
+++ b/src/PlaywrightSharp.Tests/BrowserContext/GeolocationTests.cs
@@ -11,6 +11,7 @@ namespace PlaywrightSharp.Tests.BrowserContext
     ///<playwright-file>geolocation.spec.js</playwright-file>
     ///<playwright-describe>Overrides.setGeolocation</playwright-describe>
     [Trait("Category", "chromium")]
+    [Trait("Category", "firefox")]
     [Collection(TestConstants.TestFixtureBrowserCollectionName)]
     public class GeolocationTests : PlaywrightSharpPageBaseTest
     {


### PR DESCRIPTION
closes #103 

this is not supported yet on firefox so none of the tests actually run 😄 