### PR TITLE
Remove Microsoft.AspNetCore.StaticFiles dependency

### DIFF
--- a/src/PlaywrightSharp/Helpers/StringExtensions.cs
+++ b/src/PlaywrightSharp/Helpers/StringExtensions.cs
@@ -770,6 +770,18 @@ namespace PlaywrightSharp.Helpers
             return new Regex(string.Concat(tokens.ToArray()));
         }
 
+        internal static string GetContentType(this string path)
+        {
+            const string defaultContentType = "application/octet-stream";
+            string extension = GetExtension(path);
+            if (extension == null)
+            {
+                return defaultContentType;
+            }
+
+            return _mappings.TryGetValue(extension, out string contentType) ? contentType : defaultContentType;
+        }
+
         internal static bool UrlMatches(this string url, string glob) => GlobToRegex(glob).Match(url).Success;
 
         internal static FilePayload ToFilePayload(this string file)
@@ -786,5 +798,21 @@ namespace PlaywrightSharp.Helpers
 
         private static bool IsQuoted(this string value)
             => value.StartsWith("\"", StringComparison.OrdinalIgnoreCase) && value.EndsWith("\"", StringComparison.OrdinalIgnoreCase);
+
+        private static string GetExtension(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return null;
+            }
+
+            int index = path.LastIndexOf('.');
+            if (index < 0)
+            {
+                return null;
+            }
+
+            return path.Substring(index);
+        }
     }
 }

--- a/src/PlaywrightSharp/PlaywrightSharp.csproj
+++ b/src/PlaywrightSharp/PlaywrightSharp.csproj
@@ -34,7 +34,6 @@
         <PackageReference Include="Esprima" Version="1.0.1270" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.1" />
         <PackageReference Include="System.Text.Json" Version="4.7.0" />
-        <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
         <PackageReference Include="Macross.Json.Extensions" Version="1.5.0" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     </ItemGroup>

--- a/src/PlaywrightSharp/PlaywrightSharp.csproj
+++ b/src/PlaywrightSharp/PlaywrightSharp.csproj
@@ -29,15 +29,6 @@
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
             <_Parameter1>PlaywrightSharp.Tests, PublicKey=$(AssemblyPublicKey)</_Parameter1>
         </AssemblyAttribute>
-        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-            <_Parameter1>PlaywrightSharp.Chromium, PublicKey=$(AssemblyPublicKey)</_Parameter1>
-        </AssemblyAttribute>
-        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-            <_Parameter1>PlaywrightSharp.Firefox, PublicKey=$(AssemblyPublicKey)</_Parameter1>
-        </AssemblyAttribute>
-        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-            <_Parameter1>PlaywrightSharp.Webkit, PublicKey=$(AssemblyPublicKey)</_Parameter1>
-        </AssemblyAttribute>
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Esprima" Version="1.0.1270" />

--- a/src/PlaywrightSharp/Route.cs
+++ b/src/PlaywrightSharp/Route.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.StaticFiles;
+using PlaywrightSharp.Helpers;
 using PlaywrightSharp.Transport;
 using PlaywrightSharp.Transport.Channels;
 using PlaywrightSharp.Transport.Protocol;
@@ -108,9 +108,7 @@ namespace PlaywrightSharp
             }
             else if (!string.IsNullOrEmpty(response.Path))
             {
-                new FileExtensionContentTypeProvider().TryGetContentType(response.Path, out string contentType);
-
-                headers["content-type"] = contentType ?? "application/octet-stream";
+                headers["content-type"] = response.Path.GetContentType();
             }
 
             if (length > 0 && !headers.ContainsKey("content-length"))


### PR DESCRIPTION
Reused existing code to replace the need for `Microsoft.AspNetCore.StaticFiles`.
Also removed old `InternalsVisibleTo` attributes to the legacy projects.